### PR TITLE
FMM now dynamically finds .dat, .map, and .bin files in the maps folder

### DIFF
--- a/FoundationMM/FodyWeavers.xml
+++ b/FoundationMM/FodyWeavers.xml
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers>
-	<Costura/>
   
 </Weavers>

--- a/FoundationMM/FoundationMM.csproj
+++ b/FoundationMM/FoundationMM.csproj
@@ -168,13 +168,6 @@
     <None Include="Resources\ico_up.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.1.28.3\build\Fody.targets" Condition="Exists('..\packages\Fody.1.28.3\build\Fody.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.1.28.3\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.28.3\build\Fody.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/FoundationMM/Window.cs
+++ b/FoundationMM/Window.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;
+using System.Linq;
 
 using Ini;
 
@@ -11,32 +12,17 @@ namespace FoundationMM
 {
     public partial class Window : Form
     {
-        string[] files = {
-                    @"fonts\font_package.bin",
-                    "audio.dat",
-                    "bunkerworld.map",
-                    "chill.map",
-                    "cyberdyne.map",
-                    "deadlock.map",
-                    "guardian.map",
-                    "mainmenu.map",
-                    "resources.dat",
-                    "riverworld.map",
-                    "s3d_avalanche.map",
-                    "s3d_edge.map",
-                    "s3d_reactor.map",
-                    "s3d_turf.map",
-                    "shrine.map",
-                    "string_ids.dat",
-                    "tags.dat",
-                    "textures.dat",
-                    "textures_b.dat",
-                    "video.dat",
-                    "zanzibar.map"
-                };
+        public static string[] ResetFilesVar()
+        {
+            string[] files_temp = (Directory.EnumerateFiles("maps", "*.*", SearchOption.AllDirectories).Where(s => s.EndsWith(".bin") || s.EndsWith(".map") || s.EndsWith(".dat"))).ToArray();
+            string[] files_fix = files_temp.Select(x => x.Replace("maps\\", "")).ToArray();
+            string[] files = files_fix.SkipWhile(x => x.StartsWith("fmmbak")).ToArray();
+            return files;
+        }
+
+        public string[] files = ResetFilesVar();
 
         List<string> locatedFMMInstallers = new List<string>();
-        
 
         public Window()
         {

--- a/FoundationMM/packages.config
+++ b/FoundationMM/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Costura.Fody" version="1.3.3.0" targetFramework="net452" developmentDependency="true" />
-  <package id="Fody" version="1.28.3" targetFramework="net452" developmentDependency="true" />
   <package id="SharpSvn.1.8-x86" version="1.8016.3866.130" targetFramework="net452" />
 </packages>

--- a/FoundationMM/worker_FileTransfer.cs
+++ b/FoundationMM/worker_FileTransfer.cs
@@ -30,8 +30,7 @@ namespace FoundationMM
                     }
                     else
                     {
-                        File.Copy(Path.Combine(mapsPath, file), Path.Combine(mapsPath, "fmmbak", file), true);
-                        i++;
+                        File.Copy(Path.Combine(mapsPath, file), Path.Combine(mapsPath, "fmmbak", file), true); i++;
                         float progress = ((float)i / (float)files.Count()) * 100;
                         worker.ReportProgress(Convert.ToInt32(progress));
                     }
@@ -48,13 +47,22 @@ namespace FoundationMM
                     }
                     else
                     {
-                        File.Copy(Path.Combine(mapsPath, "fmmbak", file), Path.Combine(mapsPath, file), true);
-                        i++;
-                        float progress = ((float)i / (float)files.Count()) * 100;
-                        worker.ReportProgress(Convert.ToInt32(progress));
+                        if (File.Exists(Path.Combine(mapsPath, "fmmbak", file)))
+                        {
+                            File.Copy(Path.Combine(mapsPath, "fmmbak", file), Path.Combine(mapsPath, file), true); i++;
+                            float progress = ((float)i / (float)files.Count()) * 100;
+                            worker.ReportProgress(Convert.ToInt32(progress));
+                        }
+                        else
+                        {
+                            //file must be part of a mod, ignore since we fresh install every time
+                            File.Delete(Path.Combine(mapsPath, file));
+                        }
                     }
                 }
             }
+
+            files = ResetFilesVar();
         }
 
         private void fileTransferWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)

--- a/FoundationMM/worker_RestoreClean.cs
+++ b/FoundationMM/worker_RestoreClean.cs
@@ -14,7 +14,6 @@ namespace FoundationMM
 
             string mapsPath = args[0];
 
-
             BackgroundWorker worker = sender as BackgroundWorker;
             int i = 0;
             foreach (string file in files)
@@ -26,12 +25,22 @@ namespace FoundationMM
                 }
                 else
                 {
-                    File.Copy(Path.Combine(mapsPath, "fmmbak", file), Path.Combine(mapsPath, file), true);
-                    i++;
-                    float progress = ((float)i / (float)files.Count()) * 100;
-                    worker.ReportProgress(Convert.ToInt32(progress));
+                    if (File.Exists(Path.Combine(mapsPath, "fmmbak", file)))
+                    {
+                        File.Copy(Path.Combine(mapsPath, "fmmbak", file), Path.Combine(mapsPath, file), true); i++;
+                        float progress = ((float)i / (float)files.Count()) * 100;
+                        worker.ReportProgress(Convert.ToInt32(progress));
+                    }
+                    else
+                    {
+                        //file must be part of a mod, ignore since we fresh install every time
+                        File.Delete(Path.Combine(mapsPath, file));
+                    }
+                    
                 }
             }
+
+            files = ResetFilesVar();
         }
 
         private void restoreCleanWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)


### PR DESCRIPTION
This improves future compatibility in the event more official .map or .dat files were to be added. Additionally, FMM removes .map files for a properly clean restore. This actually does break FlatGrass, but [a fix for that is also requested](https://github.com/Clef-0/FMM-Mods/pull/5). 

And Yes @Clef-0, I tested it, ;^)
